### PR TITLE
dep. upgrade 09/15/25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"


### PR DESCRIPTION
> [!NOTE]
>This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension:

>gh combine-prs --query author:app/dependabot.

It combines the following PRs:

- Bump strip-ansi from 7.1.0 to 7.1.2 (#20) @app/dependabot
- Bump @types/node from 24.3.1 to 24.4.0 (#19) @app/dependabot
- Bump commander from 14.0.0 to 14.0.1 (#18) @app/dependabot
- Bump chalk from 5.6.0 to 5.6.2 (#17) @app/dependabot

## Related Issues:

- Closes #20
- Closes #19
- Closes #18
- Closes #17
